### PR TITLE
kylin network provider url updated

### DIFF
--- a/src/network-providers/kylin-provider.js
+++ b/src/network-providers/kylin-provider.js
@@ -3,7 +3,7 @@ const BaseProvider = require('./base-provider');
 
 const KylinNetworkConfig = {
     name: 'kylin',
-    url: 'https://kylin.eoscanada.com',
+    url: 'https://api.kylin.alohaeos.com',
     chainId: '5fff1dae8dc8e2fc4d5b23b2c7665c97f9e9d8edf2b6485a86ba311c25639191'
 }
 

--- a/tests/providers-tests.js
+++ b/tests/providers-tests.js
@@ -34,7 +34,7 @@ const Networks = {
     },
     kylin: {
         name: 'kylin',
-        url: 'https://kylin.eoscanada.com',
+        url: 'https://api.kylin.alohaeos.com',
         chainId: '5fff1dae8dc8e2fc4d5b23b2c7665c97f9e9d8edf2b6485a86ba311c25639191'
     },
     custom: {


### PR DESCRIPTION
As EOS Canada announced their operations shutdown a little while ago:
https://www.eoscanada.com/en/eos-canada-is-shutting-down-its-eos-mainnet-block-producer-operations-to-focus-on-dfuse

Their node stopped working so we picked another one and changed the network provider url to be able to continue to use eoslime to deploy to kylin without having to supply the url on the command line all the time...