### PR TITLE
Improve expectAssert to include optional assert message to be checked

### DIFF
--- a/cli-commands/commands/test/specific/utils/index.js
+++ b/cli-commands/commands/test/specific/utils/index.js
@@ -1,8 +1,8 @@
 const assert = require('assert');
 
 module.exports = {
-    expectAssert: async function (promise) {
-        return expectEOSError(promise, 'eosio_assert_message_exception', 'assert');
+    expectAssert: async function (promise, message) {
+        return expectEOSError(promise, 'eosio_assert_message_exception', 'assert', message);
     },
     expectMissingAuthority: async function (promise) {
         return expectEOSError(promise, 'missing_auth_exception', 'missing authority');
@@ -20,13 +20,17 @@ module.exports = {
     // }
 }
 
-const expectEOSError = async function (promise, errorType, errorInfo) {
+const expectEOSError = async function (promise, errorType, errorInfo, errorMessage) {
     try {
         await promise;
     } catch (error) {
         const message = error.message || error;
         const expectedError = message.search(errorType) >= 0;
         assert(expectedError, `Expected ${errorInfo}, got '${message}' instead`);
+        if (errorMessage) {
+            const expectedMessage = message.search(errorMessage) >= 0;
+            assert(expectedMessage, `Expected ${errorInfo} with '${errorMessage}' message, got '${message}' instead`);
+        }
         return;
     }
     assert.fail(`Expected ${errorInfo} not received`);

--- a/cli-commands/commands/test/specific/utils/index.js
+++ b/cli-commands/commands/test/specific/utils/index.js
@@ -1,11 +1,17 @@
 const assert = require('assert');
 
 module.exports = {
-    expectAssert: async function (promise, message) {
-        return expectEOSError(promise, 'eosio_assert_message_exception', 'assert', message);
+    expectAssert: async function (promise, errorMessage) {
+        const result = await expectEOSError(promise, 'eosio_assert_message_exception', 'assert');
+        if (errorMessage && result.error) {
+            result.error = result.message.search(errorMessage) >= 0;
+            result.text = `Expected assert with '${errorMessage}' message, got '${result.message}' instead`;
+        }
+        assert(result.error, result.text);
     },
     expectMissingAuthority: async function (promise) {
-        return expectEOSError(promise, 'missing_auth_exception', 'missing authority');
+        const result = await expectEOSError(promise, 'missing_auth_exception', 'missing authority');
+        assert(result.error, result.text);
     },
     // Todo: Uncomment it once test cli command is ready
     // createTestingAccounts: async function () {
@@ -20,18 +26,17 @@ module.exports = {
     // }
 }
 
-const expectEOSError = async function (promise, errorType, errorInfo, errorMessage) {
+const expectEOSError = async function (promise, errorType, errorInfo) {
     try {
         await promise;
     } catch (error) {
         const message = error.message || error;
         const expectedError = message.search(errorType) >= 0;
-        assert(expectedError, `Expected ${errorInfo}, got '${message}' instead`);
-        if (errorMessage) {
-            const expectedMessage = message.search(errorMessage) >= 0;
-            assert(expectedMessage, `Expected ${errorInfo} with '${errorMessage}' message, got '${message}' instead`);
-        }
-        return;
+        return {
+            message,
+            error: expectedError,
+            text: `Expected ${errorInfo}, got '${message}' instead`
+        };
     }
     assert.fail(`Expected ${errorInfo} not received`);
 }

--- a/tests/cli-commands/test-tests.js
+++ b/tests/cli-commands/test-tests.js
@@ -195,7 +195,7 @@ describe('Test Command', function () {
 
         describe('Test utils', function () {
 
-            async function expect (promise, expectCb) {
+            async function expect (promise, expectCb, message) {
                 const testCommand = new TestCommand(class TestFramework {
                     setDescribeArgs () { }
                     runTests () { }
@@ -206,7 +206,8 @@ describe('Test Command', function () {
                     logger.on('success', async () => {
                         try {
                             await args.eoslime.tests[expectCb](
-                                promise
+                                promise,
+                                message
                             )
                             resolve(true);
                         } catch (error) {
@@ -231,6 +232,16 @@ describe('Test Command', function () {
                     );
                 });
 
+                it('Should expectAssert with message', async () => {
+                    await expect(
+                        new Promise((reject, resolve) => {
+                            throw new Error('eosio_assert_message_exception because: this happened');
+                        }),
+                        'expectAssert',
+                        'this happened'
+                    );
+                });
+
                 it('Should throw in case unexpected error happens', async () => {
                     try {
                         await expect(
@@ -242,6 +253,21 @@ describe('Test Command', function () {
                         assert(false);
                     } catch (error) {
                         assert(error.message.includes('Expected assert, got \'Another error\' instead'));
+                    }
+                });
+
+                it('Should throw in case of assert with unexpected message happens', async () => {
+                    try {
+                        await expect(
+                            new Promise((resolve, reject) => {
+                                throw new Error('eosio_assert_message_exception because: other thing happened');
+                            }),
+                            'expectAssert',
+                            'this happened'
+                        );
+                        assert(false);
+                    } catch (error) {
+                        assert(error.message.includes('Expected assert with \'this happened\' message, got \'eosio_assert_message_exception because: other thing happened\' instead'));
                     }
                 });
 


### PR DESCRIPTION
this PR closes issue #71 

`expectAssert(promise, [message])` if message is supplied, then the returned error has to include the message as well, otherwise the test will fail.