### PR TITLE
Added expectIrrelevantAuthority to test utils and respective unit tests

### DIFF
--- a/cli-commands/commands/test/specific/utils/index.js
+++ b/cli-commands/commands/test/specific/utils/index.js
@@ -13,6 +13,10 @@ module.exports = {
         const result = await expectEOSError(promise, 'missing_auth_exception', 'missing authority');
         assert(result.error, result.text);
     },
+    expectIrrelevantAuthority: async function (promise) {
+        const result = await expectEOSError(promise, 'irrelevant_auth_exception', 'irrelevant authority');
+        assert(result.error, result.text);
+    },
     // Todo: Uncomment it once test cli command is ready
     // createTestingAccounts: async function () {
     //     let accounts = await Account.createRandoms(10);

--- a/tests/cli-commands/test-tests.js
+++ b/tests/cli-commands/test-tests.js
@@ -324,6 +324,45 @@ describe('Test Command', function () {
                     }
                 });
             });
+
+            describe('expectIrrelevantAuthority', function () {
+                it('Should expectIrrelevantAuthority', async () => {
+                    await expect(
+                        new Promise((reject, resolve) => {
+                            throw new Error('irrelevant_auth_exception');
+                        }),
+                        'expectIrrelevantAuthority'
+                    );
+                });
+
+                it('Should throw in case unexpected error happens', async () => {
+                    try {
+                        await expect(
+                            new Promise((resolve, reject) => {
+                                throw new Error('Another error');
+                            }),
+                            'expectIrrelevantAuthority'
+                        );
+                        assert(false);
+                    } catch (error) {
+                        assert(error.message.includes('Expected irrelevant authority, got \'Another error\' instead'));
+                    }
+                });
+
+                it('Should throw in case irrelevant authority error has not been received', async () => {
+                    try {
+                        await expect(
+                            new Promise((resolve, reject) => {
+                                resolve(true);
+                            }),
+                            'expectIrrelevantAuthority'
+                        );
+                        assert(false);
+                    } catch (error) {
+                        assert(error.message.includes('Expected irrelevant authority not received'));
+                    }
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
I think this test is also relevant, since this exception is neither an assert message, nor a missing authority. Thus, since I was already playing around with the test utils, and this test became handy to my development, then I decided to add this one as well.