### PR TITLE
Feature compile multi sources in a subfolder

### DIFF
--- a/cli-commands/commands/compile/index.js
+++ b/cli-commands/commands/compile/index.js
@@ -27,8 +27,8 @@ class CompileCommand extends Command {
                 fileSysUtils.createDir(compiledDirectories.COMPILED);
 
                 for (let i = 0; i < optionsResults.path.length; i++) {
-                    const contractPath = optionsResults.path[i];
-                    await processCompilation(contractPath)
+                    const contract = optionsResults.path[i];
+                    await processCompilation(contract)
                 }
             } else {
                 MESSAGE_CONTRACT.NotFound();
@@ -41,12 +41,13 @@ class CompileCommand extends Command {
 
 const processCompilation = async function (contract) {
     try {
-        const asyncSoftExec = new AsyncSoftExec(`eosio-cpp -I . -o ./compiled/${contract.fileName}.wasm ${contract.fullPath} --abigen`);
+        const sources = contract.files.join(' ');
+        const asyncSoftExec = new AsyncSoftExec(`eosio-cpp -I . -o ./compiled/${contract.name}.wasm ${sources} --abigen`);
         await asyncSoftExec.exec();
 
-        MESSAGE_CONTRACT.Compiled(contract.fileName);
+        MESSAGE_CONTRACT.Compiled(contract.name);
     } catch (error) {
-        MESSAGE_CONTRACT.NotCompiled(error, contract.fileName);
+        MESSAGE_CONTRACT.NotCompiled(error, contract.name);
     }
 }
 


### PR DESCRIPTION
This PR implements the feature of compiling multiple source files to the same contract, if they are grouped inside a subfolder of the one that is passed to `--path`, or default `./contracts`.

This means that the behaviour is the same as before if: `./contracts/contract1.cpp` and `./contracts/contract2.cpp`,
but the new behaviour will be present if: `./contracts/mycontract/mycontract.cpp` and `./contracts/mycontract/helpers.cpp`
resulting in compiling contract `mycontract` by linking together both `mycontract.cpp` and `helpers.cpp` source files.

Also included unit tests for both behaviours as well.